### PR TITLE
Fix install on non-nft systems

### DIFF
--- a/confs/redsocks
+++ b/confs/redsocks
@@ -34,7 +34,7 @@ SCRIPTNAME=/etc/init.d/$NAME
 IPTABLES=1
 
 # Use iptables or nftables
-iptables -L nat &> /dev/null || IPTABLES=
+iptables -L &> /dev/null || IPTABLES=
 
 # Exit if the package is not installed
 [ -x $DAEMON ] || exit 0


### PR DESCRIPTION
Current version of the script looks for `iptables -L nat` on the system
to determine whether iptables or nftables are installed. In latest
Ubuntu 20.04 server atleast, nat tables do not exist and that command
will fail leading to the container assuming nftables is installed. This
is a small change to fix that scenario.

Signed-off-by: Ganesh Maharaj Mahalingam <ganesh.mahalingam@intel.com>